### PR TITLE
Support python 3.7

### DIFF
--- a/ccb/cci.py
+++ b/ccb/cci.py
@@ -23,7 +23,7 @@ class _CciInterface:
         self.owner = "conan-io"
         self.repo = "conan-center-index"
 
-    @functools.lru_cache
+    @functools.lru_cache(None)
     def pull_requests(self):
         github_token = get_github_token()
         headers = {"Accept": "application/vnd.github.v3+json"}

--- a/ccb/recipe.py
+++ b/ccb/recipe.py
@@ -3,7 +3,7 @@ import typing
 import inspect
 import logging
 import importlib.util
-from functools import cached_property, lru_cache
+from functools import lru_cache
 
 from conans import ConanFile
 
@@ -71,7 +71,8 @@ class Recipe:
         with open(self.config_path) as fil:
             return yaml.load(fil)
 
-    @cached_property
+    @property
+    @lru_cache(None)
     def upstream(self):
         return get_upstream_project(self)
 
@@ -137,7 +138,7 @@ class Recipe:
             folder = version_or_folder
         return os.path.join(self.path, folder, "conandata.yml")
 
-    @lru_cache
+    @lru_cache(None)
     def conanfile_class(self, version):
         assert isinstance(version, Version)
 


### PR DESCRIPTION
- `functools.cached_property` is not available in python 3.7
- `functools.lru_cache` requires a `None` argument (or is it better to have 1 as argument?)
- The print in `upstream_project.py` printed a `<generator>` object instead of the regex'es.

