### PR TITLE
Add mcap to PROJECT_TAGS_WHITELIST

### DIFF
--- a/ccb/project_specifics.py
+++ b/ccb/project_specifics.py
@@ -43,6 +43,7 @@ PROJECT_TAGS_WHITELIST = {
     "openimageio": [re.compile(r"^Release-([0-9]+(\.[0-9]+)+)$")],
     "thrust": [re.compile(r"^[0-9]+([\.-][0-9]+)+$")],
     "mbedtls": [re.compile(r"^mbedtls-([0-9]+(\.[0-9]+)+)$")],
+    "mcap": [re.compile(r"^releases\/cpp\/(.*)")],
 }
 
 # Project-based tag fixer, must convert the tag to a "x.y.z" version


### PR DESCRIPTION
The https://github.com/foxglove/mcap repo has different tags for multiple languages. I noticed that the bot is merging version bumps using versions from any language, not just cpp (example: https://github.com/conan-io/conan-center-index/pull/11755/files). This whitelist will use only the cpp tags.