### PR TITLE
Revert "set tools.system.package_manager config"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,6 @@ jobs:
           conan profile new default --detect
           conan profile update settings.compiler.libcxx=libstdc++11 default
           conan profile show default
-          conan config set tools.system.package_manager:mode=install
-          conan config set tools.system.package_manager:sudo=True
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/update_status.yml
+++ b/.github/workflows/update_status.yml
@@ -52,8 +52,6 @@ jobs:
           conan profile new default --detect
           conan profile update settings.compiler.libcxx=libstdc++11 default
           conan profile show default
-          conan config set tools.system.package_manager:mode=install
-          conan config set tools.system.package_manager:sudo=True
 
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Reverts qchateau/conan-center-bot#75

it fails https://github.com/qchateau/conan-center-bot/runs/7855549099?check_suite_focus=true#step:13:6137
seems to be a conan bug : https://github.com/conan-io/conan/issues/11880