### PR TITLE
bump node version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+@@ -0,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup npm
         uses: actions/setup-node@v2-beta
         with:
-          node-version: "12"
+          node-version: "16"
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Setup npm
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v3
         with:
           node-version: "16"
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build static site
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
         run: python3 setup.py sdist
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,9 @@ jobs:
 
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0}
         run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+          echo "timestamp=" >> $GITHUB_OUTPUT
+          date "+%Y-%m-%d-%H;%M;%S" >> $GITHUB_OUTPUT
 
       - name: Configure ccache cache files
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
@@ -50,7 +50,7 @@ jobs:
           message("::set-output name=timestamp::${current_date}")
 
       - name: Configure ccache cache files
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.ccache
           key: ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
@@ -125,13 +125,13 @@ jobs:
         run: python3 setup.py sdist
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: status
-          FOLDER: status
-          TARGET_FOLDER: dev
-          CLEAN: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: status
+          folder: status
+          target-folder: dev
+          clean: false
 
       - name: Publish package
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,7 @@ jobs:
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
         run: |
-          echo "timestamp=" >> $GITHUB_OUTPUT
-          date "+%Y-%m-%d-%H;%M;%S" >> $GITHUB_OUTPUT
+          echo "timestamp=$(date +%Y-%m-%d-%H-%M-%S)" >> $GITHUB_OUTPUT
 
       - name: Configure ccache cache files
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,12 @@ jobs:
 
       - name: Deploy site
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: ccb-frontend/dist
-          CLEAN: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: ccb-frontend/dist
+          clean: true
 
   ci:
     runs-on: ubuntu-20.04
@@ -76,7 +76,7 @@ jobs:
           conan profile show default
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Edit version for release
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/update_status.yml
+++ b/.github/workflows/update_status.yml
@@ -25,8 +25,7 @@ jobs:
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
         run: |
-          echo "timestamp=" >> $GITHUB_OUTPUT
-          date "+%Y-%m-%d-%H;%M;%S" >> $GITHUB_OUTPUT
+          echo "timestamp=$(date +%Y-%m-%d-%H-%M-%S)" >> $GITHUB_OUTPUT
 
       - name: Configure ccache cache files
         uses: actions/cache@v3

--- a/.github/workflows/update_status.yml
+++ b/.github/workflows/update_status.yml
@@ -24,10 +24,9 @@ jobs:
 
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0}
         run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+          echo "timestamp=" >> $GITHUB_OUTPUT
+          date "+%Y-%m-%d-%H;%M;%S" >> $GITHUB_OUTPUT
 
       - name: Configure ccache cache files
         uses: actions/cache@v3

--- a/.github/workflows/update_status.yml
+++ b/.github/workflows/update_status.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
@@ -30,7 +30,7 @@ jobs:
           message("::set-output name=timestamp::${current_date}")
 
       - name: Configure ccache cache files
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.ccache
           key: ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
@@ -56,7 +56,7 @@ jobs:
           conan profile show default
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install CCB locally
         run: python3 -m pip install .
@@ -95,10 +95,10 @@ jobs:
         run: sleep 300
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: status
-          FOLDER: status
-          TARGET_FOLDER: prod
-          CLEAN: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: status
+          folder: status
+          target-folder: prod
+          clean: false

--- a/.github/workflows/update_status.yml
+++ b/.github/workflows/update_status.yml
@@ -95,7 +95,7 @@ jobs:
         run: sleep 300
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: status


### PR DESCRIPTION
it fixes a warning: `Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/` https://github.com/qchateau/conan-center-bot/actions/runs/3261645063/jobs/5357006354

Another warning needs to be fixed : `The `set-output` command is deprecated and will be disabled soon` https://github.com/qchateau/conan-center-bot/actions/runs/3261645063/jobs/5357006354#step:3:11 which happens on line https://github.com/qchateau/conan-center-bot/blob/master/.github/workflows/ci.yml#L50
I'm not sure what the best way to fix this one. https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable recommends to write to `$GITHUB_ENV` file, but is it the best way to do it from a cmake script ? do you have a suggestion @qchateau 